### PR TITLE
Update: missing sqrts

### DIFF
--- a/src/postprocess.jl
+++ b/src/postprocess.jl
@@ -68,13 +68,13 @@ function calc_forces(surf::TwoDSurfwFlap)
     nonl_m2 = 0
     for ib = 1:surf.ndiv-1
         # 1st three terms in delta p, Ucos(),hdotsin(), alphadot*eta integrated
-        nonl_cnc = nonl_cnc + (1+surf.cam_slope[ib]*surf.cam_slope[ib])*(surf.kinem.u*cos(surf.kinem.alpha)+surf.kinem.hdot*sin(surf.kinem.alpha) - surf.kinem.alphadot*surf.cam[ib])*surf.bv[ib].s  
+        nonl_cnc = nonl_cnc + sqrt(1+surf.cam_slope[ib]*surf.cam_slope[ib])*(surf.kinem.u*cos(surf.kinem.alpha)+surf.kinem.hdot*sin(surf.kinem.alpha) - surf.kinem.alphadot*surf.cam[ib])*surf.bv[ib].s  
         # Same term as before with additional squared spatial derivative term
-        nonl = nonl + (1+surf.cam_slope[ib]*surf.cam_slope[ib])*(surf.uind[ib]*cos(surf.kinem.alpha) - surf.wind[ib]*sin(surf.kinem.alpha))*surf.bv[ib].s
+        nonl = nonl + sqrt(1+surf.cam_slope[ib]*surf.cam_slope[ib])*(surf.uind[ib]*cos(surf.kinem.alpha) - surf.wind[ib]*sin(surf.kinem.alpha))*surf.bv[ib].s
         # Same term as before with additional squared spatial derivative term and alphadot*eta term
-        nonl_m1 = nonl_m1 + surf.x[ib]*(1+surf.cam_slope[ib]*surf.cam_slope[ib])*(surf.kinem.u*cos(surf.kinem.alpha)+surf.kinem.hdot*sin(surf.kinem.alpha) - surf.kinem.alphadot*surf.cam[ib])*surf.x[ib]surf.bv[ib].s
+        nonl_m1 = nonl_m1 + surf.x[ib]*sqrt(1+surf.cam_slope[ib]*surf.cam_slope[ib])*(surf.kinem.u*cos(surf.kinem.alpha)+surf.kinem.hdot*sin(surf.kinem.alpha) - surf.kinem.alphadot*surf.cam[ib])*surf.x[ib]surf.bv[ib].s
         # Same term as before with additional squared spatial derivative term
-        nonl_m = nonl_m + (1+surf.cam_slope[ib]*surf.cam_slope[ib])*(surf.uind[ib]*cos(surf.kinem.alpha) - surf.wind[ib]*sin(surf.kinem.alpha))*surf.x[ib]*surf.bv[ib].s
+        nonl_m = nonl_m + sqrt(1+surf.cam_slope[ib]*surf.cam_slope[ib])*(surf.uind[ib]*cos(surf.kinem.alpha) - surf.wind[ib]*sin(surf.kinem.alpha))*surf.x[ib]*surf.bv[ib].s
     end
     nonl = nonl*2./(surf.uref*surf.uref*surf.c)
     nonl_cnc = nonl_cnc*2./(surf.uref*surf.uref*surf.c)


### PR DESCRIPTION
The expressions for lift and moment coefficients were missing a sqrt for the 1+cam_slope_der^2 terms.